### PR TITLE
Automate GitHub Pages deployment via GitHub Actions

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -9,6 +9,17 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; let in-progress runs finish rather than
+# cancelling a deploy mid-way.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -66,3 +77,22 @@ jobs:
 
       - name: Build book (pdf)
         run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
+
+      # Pull requests only need the build to be validated, not published.
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@
 
 ### Build/release notes
 
-- The published site is served from `docs/` (GitHub Pages).
-- `bookdown::gitbook` output is written to `docs/` per `_bookdown.yml`.
+- The published site is deployed automatically by the `Build Book` GitHub Actions
+  workflow (`.github/workflows/build-book.yml`): every push to `main`/`master`
+  builds the book and publishes it to GitHub Pages via
+  `actions/deploy-pages`. Pull requests and scheduled runs only validate that
+  the book builds; they do not publish.
+- This requires the repository's Pages source (Settings > Pages) to be set to
+  "GitHub Actions" rather than "Deploy from a branch".
+- `bookdown::gitbook` output is written to `docs/` per `_bookdown.yml`. The
+  committed copy of `docs/` is kept for local browsing/history only — it is
+  no longer what GitHub Pages serves from, and no longer needs to be rebuilt
+  and committed by hand to publish a change.
 
 ### Data provenance
 
@@ -31,4 +40,4 @@
 - Check schedule times are OK and confirm that the times are correct by cross-referencing the outputs on the website with the official calendar.
 - Edit the Instructors part of `index.Rmd` to add/remove instructors as appropriate.
 - Edit the Excel schedule `BB512_Schedule.xlsx` to put the instructors in the correct place.
-- Rebuild GitHub site. (`Build Book` button in RStudio)
+- No manual rebuild/publish step is needed — merging to `main`/`master` triggers an automatic build and deploy to GitHub Pages.


### PR DESCRIPTION
## Summary
- Splits the `Build Book` workflow into a `build` job (unchanged) and a `deploy` job that publishes `docs/` to GitHub Pages using `actions/upload-pages-artifact` + `actions/deploy-pages`.
- Deploy is gated to skip `pull_request` events, so PRs only validate the build; pushes to `main`/`master`, the weekly schedule, and manual dispatch will publish.
- Adds the `pages: write` / `id-token: write` permissions and a `concurrency` group needed for the official GitHub Pages Actions deployment pattern.
- Updates `README.md` to describe the new automatic-deploy flow and removes the now-stale "rebuild and commit `docs/`" manual instruction.

## Context
PR #5 (already merged) covered the content/accuracy review of the course book. This follow-up implements automatic GitHub Pages deployment, which was discussed separately. It was originally pushed to the same branch before #5 was merged, so it's being resubmitted here as its own PR, rebased onto the current `master`.

**Note:** this requires the repository's Pages source (Settings → Pages) to be set to "GitHub Actions" rather than "Deploy from a branch" — the repo owner has already made that change.

## Test plan
- [ ] Confirm the `build` job still passes (gitbook + PDF render cleanly).
- [ ] Confirm the `deploy` job succeeds and publishes to GitHub Pages on merge to `master`.
- [ ] Spot-check the live Pages URL reflects the deployed content after merge.

https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb

---
_Generated by [Claude Code](https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb)_