### PR TITLE
Fix code review findings: allele tracking, lambda estimate, and ZNGI labels

### DIFF
--- a/2_04_BasicLogisticGrowth.Rmd
+++ b/2_04_BasicLogisticGrowth.Rmd
@@ -260,8 +260,13 @@ for (t in 2:timesteps) {
   }
   
   # Calculate per capita growth rate for the previous time step
-  per_capita_growth[t-1] <- (population[t] - 
-                               population[t-1]) / population[t-1]
+  # (undefined if the previous population was zero)
+  if (population[t-1] > 0) {
+    per_capita_growth[t-1] <- (population[t] -
+                                 population[t-1]) / population[t-1]
+  } else {
+    per_capita_growth[t-1] <- NA
+  }
 }
 
 par(mfrow=c(1,2))

--- a/2_09_LTRE.Rmd
+++ b/2_09_LTRE.Rmd
@@ -18,13 +18,14 @@ Learning outcomes:
 
 ## Set up
 
-For the core LTRE analysis, you only need `popbio`.
+For the core LTRE analysis you need `popbio` (for the `LTRE` function) and `popdemo` (for the `eigs` function used to compare growth rates).
 The diagram-export packages are optional and only needed if you want to regenerate the life-cycle diagram image.
 
 ```{r LTRE1, echo = TRUE, eval = FALSE}
-# Core package (required)
-install.packages("popbio")
+# Core packages (required)
+install.packages(c("popbio", "popdemo"))
 library(popbio)
+library(popdemo)
 
 # Optional packages (only for rebuilding the diagram figure)
 install.packages(c("Rage", "DiagrammeRsvg", "rsvg"))

--- a/3_02_GenePool.Rmd
+++ b/3_02_GenePool.Rmd
@@ -164,9 +164,9 @@ for (i in 2:n_gen) {
     pop_size * 2,
     replace = TRUE
   )
-  gene_pool_table <- table(factor(gene_pool_time_n_plus_1, 
+  gene_pool_table <- table(factor(gene_pool_time_n_plus_1,
                                   levels = c("A", "a")))
-  allele_freq_A[i] <- gene_pool_table[2] / sum(gene_pool_table)
+  allele_freq_A[i] <- gene_pool_table["A"] / sum(gene_pool_table)
 
   # Replace the old gene pool with the new one.
   gene_pool_time_n <- gene_pool_time_n_plus_1
@@ -241,7 +241,7 @@ for (i in 2:n_gen) {
   )
   gene_pool_table <- table(factor(gene_pool_time_n_plus_1,
                                   levels = c("A", "a")))
-  allele_freq_A[i] <- gene_pool_table[2] / sum(gene_pool_table)
+  allele_freq_A[i] <- gene_pool_table["A"] / sum(gene_pool_table)
 
   # Replace the old gene pool with the new one.
   gene_pool_time_n <- gene_pool_time_n_plus_1

--- a/4_03_LotkaVolterraPredatorPrey_continuousTime.Rmd
+++ b/4_03_LotkaVolterraPredatorPrey_continuousTime.Rmd
@@ -122,11 +122,11 @@ plot(output_df$V, output_df$C, type = "l", col = "purple", lwd = 2,
      xlab = "Victim (V)", ylab = "Consumer (C)", 
      main = "Predator-Prey Dynamics with ZNGIs")
 
-# Victim ZNGI
-abline(v = parameters["q"] / (parameters["a"] * parameters["f"]), col = "blue", 
-       lwd = 2, lty = 2)  
-# Consumer ZNGI
-abline(h = parameters["R"] / parameters["a"], col = "red", lwd = 2, lty = 2)  
+# Consumer ZNGI: dC/dt = 0 when V = q / (a * f) (a vertical line)
+abline(v = parameters["q"] / (parameters["a"] * parameters["f"]), col = "red",
+       lwd = 2, lty = 2)
+# Victim ZNGI: dV/dt = 0 when C = R / a (a horizontal line)
+abline(h = parameters["R"] / parameters["a"], col = "blue", lwd = 2, lty = 2)
 
 # Add point for initial population sizes
 points(output_df$V[1], output_df$C[1], pch = 19, col = "black", cex = 1.5)

--- a/4_04_LotkaVolterraPredatorPrey_discreteTime.Rmd
+++ b/4_04_LotkaVolterraPredatorPrey_discreteTime.Rmd
@@ -132,12 +132,12 @@ plot(output_df$V,
      xlab = "Victim (V)", ylab = "Consumer (C)", 
      main = "Discrete Predator-Prey Dynamics with ZNGIs")
 
-# Add Victim ZNGI (V = q / (a * f))
-abline(v = parameters["q"] / (parameters["a"] * parameters["f"]), 
-       col = "blue", lwd = 2, lty = 2)
+# Add Consumer ZNGI: dC/dt = 0 when V = q / (a * f) (a vertical line)
+abline(v = parameters["q"] / (parameters["a"] * parameters["f"]),
+       col = "red", lwd = 2, lty = 2)
 
-# Add Consumer ZNGI (C = R / a)
-abline(h = parameters["R"] / parameters["a"], col = "red", lwd = 2, lty = 2)
+# Add Victim ZNGI: dV/dt = 0 when C = R / a (a horizontal line)
+abline(h = parameters["R"] / parameters["a"], col = "blue", lwd = 2, lty = 2)
 
 # Add point for initial population sizes
 points(output_df$V[1], output_df$C[1], pch = 19, col = "black", cex = 1.5)

--- a/7_01_LambdaAndR.Rmd
+++ b/7_01_LambdaAndR.Rmd
@@ -170,7 +170,7 @@ summary(mod1)
 
 Interpretation
 
-The summary of the model indicates that the slope of the relationship between year and logN is `r as.vector(mod1$coefficients[2])`. Therefore, the per capita growth rate ($R$) is `r round(as.vector(coef(mod1)[2]),3)` and the population multiplication rate ($\lambda$) is `r 1+round(as.vector(coef(mod1)[2]),3)`.
+The summary of the model indicates that the slope of the relationship between year and logN is `r as.vector(mod1$coefficients[2])`. This slope is $\ln(\lambda)$, so the population multiplication rate ($\lambda$) is $e^{\text{slope}}$ = `r round(exp(as.vector(coef(mod1)[2])),3)`, the intrinsic rate of increase ($r$) is the slope itself = `r round(as.vector(coef(mod1)[2]),3)`, and the per capita rate of increase ($R = \lambda - 1$) is `r round(exp(as.vector(coef(mod1)[2]))-1,3)`.
 
 This suggests that the number of breeding pairs is indeed growing exponentially over the time period studied, with a specific rate of increase. Understanding this rate is crucial for conservation efforts, because it provides insights into the population's resilience, its demands on the ecosystem, and how it might respond to future changes in environmental conditions or conservation policies.
 

--- a/7_02_Ambalappuzha.Rmd
+++ b/7_02_Ambalappuzha.Rmd
@@ -99,4 +99,4 @@ Output:
 sum(myData$nRice)
 ```
 
-To put that *HUGE* number in context, if a grain of rice weighs 25mg (0.0000025kg), then we'd have `r format((2^64 - 1) * 0.000025, big.mark = ",", scientific = FALSE)` kg. That's 461 Gigatonnes, or roughly 8-900 times the yearly global rice production!
+To put that *HUGE* number in context, if a grain of rice weighs 25mg (0.000025kg), then we'd have `r format((2^64 - 1) * 0.000025, big.mark = ",", scientific = FALSE)` kg. That's 461 Gigatonnes, or roughly 8-900 times the yearly global rice production!

--- a/index.Rmd
+++ b/index.Rmd
@@ -245,7 +245,7 @@ cat("The formatted schedule table appears only in the online version of this boo
 - Official SDU timetable (always up to date): <", link_to_schedule, ">
 - For dates, times and rooms, also check itsLearning.
 
-")
+", sep = "")
 ```
 
 ```{r echo = FALSE, message = FALSE, warning = FALSE}


### PR DESCRIPTION
Correctness fixes:
- GenePool: track allele A (gene_pool_table["A"]) instead of index [2],
  which was the count of allele "a", so the plotted series and the
  allele_freq_A variable now match their labels.
- LambdaAndR: the regression slope of ln(N)~year is ln(lambda), so
  compute lambda = exp(slope) (was 1 + slope) and distinguish r, R and
  lambda correctly. This matches the EstimatingLambda chapter and the
  chapter's own warning against lambda = r + 1.
- Predator-prey (continuous and discrete): swap the ZNGI labels/colours
  so the vertical line V = q/(a*f) is the consumer isocline and the
  horizontal line C = R/a is the victim isocline.

Minor fixes:
- Ambalappuzha: correct 25 mg = 0.000025 kg in the parenthetical.
- LTRE: note that popdemo is also required (used by eigs), not just popbio.
- index: cat(sep = "") so the PDF schedule URL autolinks correctly.
- BasicLogisticGrowth: guard the per-capita growth calculation against a
  zero previous population.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ViDQPCmk7oGhjLNDVABfoE