### PR TITLE
Fix failing CI build (libuv1-dev) and mislabelled Hawk-Dove payoff

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -62,7 +62,8 @@ jobs:
             libjpeg-dev \
             libtiff5-dev \
             libgit2-dev \
-            libglpk-dev
+            libglpk-dev \
+            libuv1-dev
 
       - name: Install R packages
         run: |

--- a/6_02_HawkDoveResults.Rmd
+++ b/6_02_HawkDoveResults.Rmd
@@ -60,12 +60,12 @@ hawkishness <- bind_rows(hawkishness1,hawkishness2)
 perIndiv_player1 <- hdg %>%
   mutate(hawkNumeric_player1 = ifelse(player_1_card == "Hawk", 1, 0)) %>%
   group_by(teamID) %>%
-  summarise(mean_Hawkishness = mean(hawkNumeric_player1), mean_benefit = sum(player_1_benefit, na.rm = TRUE))
+  summarise(mean_Hawkishness = mean(hawkNumeric_player1), total_benefit = sum(player_1_benefit, na.rm = TRUE))
 
 perIndiv_player2 <- hdg %>%
   mutate(hawkNumeric_player2 = ifelse(player_2_card == "Hawk", 1, 0)) %>%
   group_by(teamID) %>%
-  summarise(mean_Hawkishness = mean(hawkNumeric_player2), mean_benefit = sum(player_2_benefit, na.rm = TRUE))
+  summarise(mean_Hawkishness = mean(hawkNumeric_player2), total_benefit = sum(player_2_benefit, na.rm = TRUE))
 
 perIndiv_bothPlayers <- bind_rows(perIndiv_player2,perIndiv_player1)
 ```
@@ -111,12 +111,12 @@ What we see is that the maximum benefits are received when hawkishness is at an 
 
 
 ```{r hawkdoveresults6, echo = FALSE, message = FALSE}
-ggplot(perIndiv_bothPlayers,aes(x = mean_Hawkishness,y = mean_benefit)) + 
-  geom_point() + 
+ggplot(perIndiv_bothPlayers,aes(x = mean_Hawkishness,y = total_benefit)) +
+  geom_point() +
   stat_smooth(method="lm",formula=y~poly(x, 2),fullrange=TRUE)+
-  ggtitle("The best strategy in Game 1\nis an intermediate level of hawkishness") + 
+  ggtitle("The best strategy in Game 1\nis an intermediate level of hawkishness") +
   xlim(0,1) +
-  ylab("Mean benefit") + 
+  ylab("Total benefit") +
   xlab("Mean hawkishness")
 ```
 
@@ -184,11 +184,13 @@ Finally we can look at what the best strategy is in Game 2.
 perIndiv <- hdg2 %>%
   mutate(hawkNumeric_player1 = ifelse(player_1 == "H", 1, 0)) %>%
   group_by(individual) %>%
-  summarise(meanHawkishness = mean(hawkNumeric_player1), benefit = sum(benefit, na.rm = TRUE))
+  summarise(meanHawkishness = mean(hawkNumeric_player1), total_benefit = sum(benefit, na.rm = TRUE))
 
-ggplot(perIndiv,aes(x = meanHawkishness,y = benefit)) + 
-  geom_point() + 
-  geom_smooth(method="lm", formula=y~poly(x, 2))
+ggplot(perIndiv,aes(x = meanHawkishness,y = total_benefit)) +
+  geom_point() +
+  geom_smooth(method="lm", formula=y~poly(x, 2)) +
+  ylab("Total benefit") +
+  xlab("Mean hawkishness")
 
 ```
 


### PR DESCRIPTION
## Summary

Rebased onto the latest `master`. Since PR #6 already added GitHub Pages auto-deployment (via `upload-pages-artifact` + `deploy-pages`), my earlier "commit `docs/` back" approach was redundant and conflicting, so I dropped it. What remains are the two changes still needed:

1. **`1861b2a` — CI: install `libuv1-dev`.** The "Build Book" workflow fails while installing R packages: `fs` (v2.1.0) now compiles from source and needs `libuv` (`uv.h`), which isn't in the apt-get list. `fs` fails to configure, so everything depending on it (sass, bslib, rmarkdown, bookdown, tidyverse, flextable, Rage, googledrive, …) fails to install and the build aborts — **before** the Pages artifact is ever uploaded/deployed. Adding `libuv1-dev` restores the build, which is what actually lets PR #6's deploy step run.

2. **`dead17f` — Content: label Hawk-Dove payoff as total, not mean.** In `6_02_HawkDoveResults.Rmd` the per-player benefit is a `sum()` over rounds, but it was named `mean_benefit` and plotted with a "Mean benefit" axis. Renamed to `total_benefit` and relabelled both Game 1 and Game 2 plots. Only rescales by a constant, so the fitted relationship and interpretation are unchanged.

## Why this matters

PR #6 set up automatic publishing, but the build has been red since ~April (the `libuv` issue), so nothing has actually been rendered or deployed. This PR gets the build green again so the existing deploy pipeline can publish — including the accumulated source fixes from earlier (λ estimate, gene-pool allele, predator-prey ZNGI labels).

Merges cleanly onto current `master`; no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)