### PR TITLE
Render the full book to a single combined Markdown file in CI

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -78,6 +78,19 @@ jobs:
 
       - name: Build book (pdf)
         run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
+
+      # A single combined Markdown file for offline/private reading - not
+      # needed to validate a PR, only built and committed on push/schedule.
+      - name: Build book (single markdown)
+        if: github.event_name != 'pull_request'
+        run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::markdown_document2', output_dir = 'full-book')"
+
+      - name: Commit combined markdown
+        if: github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Rebuild full-book/BB512.md"
+          file_pattern: "full-book/**"
 
       # Pull requests only need the build to be validated, not published.
       - name: Upload Pages artifact

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
   committed copy of `docs/` is kept for local browsing/history only — it is
   no longer what GitHub Pages serves from, and no longer needs to be rebuilt
   and committed by hand to publish a change.
+- The same workflow also renders the whole book to a single combined
+  Markdown file, `full-book/BB512.md` (with figures evaluated and embedded,
+  via `bookdown::markdown_document2`), and commits it back to the repo on
+  every push/schedule run (not on pull requests). This is for offline/private
+  reading — view or download it directly from the GitHub file browser.
 
 ### Data provenance
 


### PR DESCRIPTION
## Summary
Adds a step to the existing `Build Book` workflow that renders the whole bookdown project to a single combined Markdown file, `full-book/BB512.md`, using `bookdown::markdown_document2` — figures get evaluated and embedded as images, dynamic `` `r ...` `` values get computed, same as the live site, just as one plain-Markdown file instead of a multi-page gitbook.

**Why this approach:** rather than installing R locally to render this, this reuses the R/bookdown/pandoc toolchain the workflow already sets up for the gitbook/PDF builds — no new dependencies, no separate maintenance burden.

## Changes
- New step `Build book (single markdown)`: `bookdown::render_book('index.Rmd', 'bookdown::markdown_document2', output_dir = 'full-book')`. Gated to non-PR events (not needed to validate a PR — the gitbook/PDF builds already validate rendering).
- New step `Commit combined markdown`: uses `stefanzweifel/git-auto-commit-action@v5` to commit `full-book/**` back to the repo when it changes, only on push/schedule runs.
- Bumps the workflow's `contents` permission from `read` to `write` so the auto-commit step can push.
- Documents the new output in `README.md`.

## Why commit it to the repo (vs. a build artifact)
This is for private/offline reading, and the goal was "downloadable from GitHub on the web" — a committed file is directly browsable/downloadable from the normal GitHub file view, with no expiry, versus a workflow-run artifact (which expires and requires navigating to the Actions tab).

## Test plan
- [ ] Confirm the `Build book (single markdown)` step succeeds and produces `full-book/BB512.md` with real evaluated content (not raw `` `r ...` `` source) and embedded figure images.
- [ ] Confirm the auto-commit step only fires on push/schedule, not on this PR's own validation run.
- [ ] Spot-check `full-book/BB512.md` renders reasonably when viewed in GitHub's file browser.

https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb

---
_Generated by [Claude Code](https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb)_