### PR TITLE
Fix broken Build Book workflow: allow HTML output in markdown render

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -4,6 +4,7 @@ author: "Owen R. Jones (Course Coordinator)"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
 pandoc_args: --listings
+always_allow_html: true
 output:
   bookdown::gitbook:
     config:


### PR DESCRIPTION
## Summary
The last push to `master` (merging #11) actually **failed** and never deployed to Pages, because the new "Build book (single markdown)" step errored out:

```
Error: Functions that produce HTML output found in document targeting
markdown_strict-yaml_metadata_block output.
```

Because a failed step aborts the rest of the job, this also skipped `Upload Pages artifact` and the `deploy` job — so the last push to `master` did not publish anything to GitHub Pages.

## Root cause
Some content in the book (e.g. `flextable` widgets) only knows how to render as HTML or LaTeX. `bookdown::markdown_document2` targets plain Markdown, which `rmarkdown`/`knitr` doesn't recognise as HTML-capable, so it hard-errors unless explicitly told it's OK to embed raw HTML.

`gitbook` and `pdf_book` are unaffected: `gitbook` is HTML by definition, and the one known HTML-producing chunk (the schedule `flextable` table) already has `eval = knitr::is_html_output()` / `is_latex_output()` guards for the PDF path — so PDF never hit this.

## Fix
Added `always_allow_html: true` to `index.Rmd`'s YAML front matter, which is the fix `rmarkdown` itself suggests in the error message.

## Test plan
- [ ] Confirm `Build book (single markdown)` now succeeds on push to `master`.
- [ ] Confirm `full-book/BB512.md` gets committed with real evaluated content.
- [ ] Confirm `deploy` runs and Pages actually publishes again.

https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb

---
_Generated by [Claude Code](https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb)_