### PR TITLE
Diagnose and relocate figures for the combined markdown build

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -83,7 +83,31 @@ jobs:
       # needed to validate a PR, only built and committed on push/schedule.
       - name: Build book (single markdown)
         if: github.event_name != 'pull_request'
-        run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::markdown_document2', output_dir = 'full-book')"
+        run: |
+          touch /tmp/premd.marker
+          Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::markdown_document2', output_dir = 'full-book')"
+
+      # bookdown/pandoc can write this format's figures outside output_dir;
+      # find them (wherever they landed) and copy them into full-book/ so
+      # the relative image paths in BB512.md actually resolve, and so the
+      # commit step below picks them up. Also prints diagnostics either way.
+      - name: Relocate figures for combined markdown
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "--- full-book/ before relocation ---"
+          find full-book -maxdepth 3 || true
+          echo "--- directories matching *figure-markdown* anywhere in repo ---"
+          find . -type d -iname "*figure-markdown*" -not -path "./.git/*" || true
+          echo "--- any *.png/*.jpg/*.svg files newer than the pre-build marker ---"
+          find . -newer /tmp/premd.marker \( -iname "*.png" -o -iname "*.jpg" -o -iname "*.svg" \) -not -path "./.git/*" || true
+          for d in $(find . -maxdepth 2 -type d -iname "*figure-markdown*" -not -path "./.git/*" -not -path "./full-book/*"); do
+            target="full-book/$(dirname "$d")"
+            mkdir -p "$target"
+            cp -r "$d" "$target/"
+            echo "Copied $d -> $target/"
+          done
+          echo "--- full-book/ after relocation ---"
+          find full-book -maxdepth 3 || true
 
       - name: Commit combined markdown
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
`full-book/BB512.md` (from the previous run) renders correctly — real computed values, no leftover unevaluated `` `r ...` `` source, no stray chunk fences. But its 26 image references (e.g. `BB512_files/figure-markdown_strict/logistic_optional_r_code-1.png`) are currently dangling: no such folder exists anywhere in the committed `full-book/` directory, and I couldn't find any trace in the build logs of it being created — even though the equivalent `figure-html`/`figure-latex` folders from the gitbook/PDF builds in the same run are clearly present at the repo root and under `docs/`.

## Change
Adds a step between the markdown build and the commit step that:
1. Prints diagnostics: what currently exists under `full-book/`, any directories matching `*figure-markdown*` anywhere in the checkout, and any image files newer than a marker touched right before the markdown build.
2. Relocates any such figure directory it finds into `full-book/`, preserving relative structure, so the image paths in `BB512.md` resolve and the commit step picks them up.

## Why this approach
I don't have a live R environment to iteratively debug exactly why `bookdown::markdown_document2`'s figures end up in an unexpected location (or possibly aren't generated at all) when run in the same job as the gitbook/PDF builds. Rather than guess further, this step surfaces hard evidence in the next run's logs and fixes the common case (files just landing in the wrong place) in the same pass.

## Test plan
- [ ] Check the "Relocate figures for combined markdown" step's output on the next run.
- [ ] If figures are found and relocated: confirm `full-book/BB512.md`'s images actually display when viewed on GitHub.
- [ ] If no figures are found anywhere: that's a different, deeper problem (e.g. some chunks may not be executing for this format at all) that will need further investigation with the diagnostic output in hand.

https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb

---
_Generated by [Claude Code](https://claude.ai/code/session_013E6MhjHctrfhStoYEVkkTb)_